### PR TITLE
Expose scatter forces for sliced cubes

### DIFF
--- a/Assets/Models/Cube.prefab
+++ b/Assets/Models/Cube.prefab
@@ -136,6 +136,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   correctDirection: 2
+  explosionForce: 8
+  torqueForce: 10
 --- !u!54 &-1207250622501321389
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Box_Down.prefab
+++ b/Assets/Prefabs/Box_Down.prefab
@@ -104,6 +104,8 @@ MonoBehaviour:
   slicedVersionDown: {fileID: 919132149155446097, guid: 4a34ce17251fd4263989aec2e4fd332a, type: 3}
   slicedVersionLeft: {fileID: 0}
   slicedVersionRight: {fileID: 0}
+  explosionForce: 8
+  torqueForce: 10
 --- !u!114 &3985705771477177324
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Box_Left.prefab
+++ b/Assets/Prefabs/Box_Left.prefab
@@ -104,6 +104,8 @@ MonoBehaviour:
   slicedVersionDown: {fileID: 0}
   slicedVersionLeft: {fileID: 919132149155446097, guid: 7566a748f6b0f4cba9933d1893b1fb4a, type: 3}
   slicedVersionRight: {fileID: 0}
+  explosionForce: 8
+  torqueForce: 10
 --- !u!114 &7233361482696124286
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Box_Right.prefab
+++ b/Assets/Prefabs/Box_Right.prefab
@@ -104,6 +104,8 @@ MonoBehaviour:
   slicedVersionDown: {fileID: 0}
   slicedVersionLeft: {fileID: 0}
   slicedVersionRight: {fileID: 919132149155446097, guid: 21623c1ec143d451eaab84549f44e195, type: 3}
+  explosionForce: 8
+  torqueForce: 10
 --- !u!114 &4466101828258221038
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Box_Up.prefab
+++ b/Assets/Prefabs/Box_Up.prefab
@@ -104,6 +104,8 @@ MonoBehaviour:
   slicedVersionDown: {fileID: 0}
   slicedVersionLeft: {fileID: 0}
   slicedVersionRight: {fileID: 0}
+  explosionForce: 8
+  torqueForce: 10
 --- !u!114 &3796795367326470047
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CubeBehavior.cs
+++ b/Assets/Scripts/CubeBehavior.cs
@@ -10,6 +10,9 @@ public class CubeBehavior : MonoBehaviour
 
     public InputManager.Direction correctDirection;
 
+    public float explosionForce = 8f;
+    public float torqueForce = 10f;
+
     public void Slice(InputManager.Direction swipeDir)
     {
         GameObject slicedVersion = null;
@@ -60,8 +63,8 @@ public class CubeBehavior : MonoBehaviour
         {
             Vector3 forceDir = (rb.transform.position - transform.position).normalized;
             forceDir += Random.insideUnitSphere * 0.5f;
-            rb.AddForce(forceDir * 8f, ForceMode.Impulse);
-            rb.AddTorque(Random.insideUnitSphere * 10f, ForceMode.Impulse);
+            rb.AddForce(forceDir * explosionForce, ForceMode.Impulse);
+            rb.AddTorque(Random.insideUnitSphere * torqueForce, ForceMode.Impulse);
         }
 
         Destroy(sliced, 2f);


### PR DESCRIPTION
## Summary
- allow customizing scatter forces in `CubeBehavior`
- update box and cube prefabs with default scatter force values

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857fcb224d48321b91f64fec11b25a3